### PR TITLE
FIX: Missing migration 006 in setup.php

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -8,6 +8,7 @@
     include 'migrations/003_add_reports.php';
     include 'migrations/004_add_raw_packets.php';
     include 'migrations/005_add_reporter_style.php';
+    include 'migrations/006_add_contact_last_heard.php';
 
     // Must be in order!
     $migrationClasses = array(
@@ -17,6 +18,7 @@
         'Migration_003',
         'Migration_004',
         'Migration_005',
+        'Migration_006',
     );
 
     session_start();


### PR DESCRIPTION
Hello @Anrijs,
thank you for Meshlog.

I'm running a little modified version on Meshlog here in Slovakia,
and i'm not sure about the latest migration scripts - version defined in meshlog.class.php = 6, but migration 006 is missing in setup.php.

When i upgrade i get stuck between - upgrade and Already setup message.

Please check.
Thank you!